### PR TITLE
resolving Issue43 : improving verbosity and error messages for offline data 

### DIFF
--- a/modules/moduleYamlManagement.py
+++ b/modules/moduleYamlManagement.py
@@ -12,7 +12,7 @@ import yaml
 # -- / internal imports 
 from modules.moduleFileManagement import createPath, gatherFilePath, gatherFolderPath
 
-def createYaml() -> Optional[Exception]:
+def createYaml() -> Optional[str]:
     '''
     searches for folders with name "test" and "valid" 
     if found: creates yaml file which contains those both folders as source for training datasets 
@@ -23,7 +23,8 @@ def createYaml() -> Optional[Exception]:
         validPath = gatherFolderPath('valid')
         
         if testPath == None or validPath == None: 
-            return Exception("Folder structure was not set up, aborting custom training")
+            # raising an exception would be useless, we could just abort by returning the error too 
+            return "testpath and validpath directories were not found"
             
         config = {
             'train': createPath(testPath, 'images'),
@@ -32,7 +33,9 @@ def createYaml() -> Optional[Exception]:
             'names': ['Helmet', 'Goggles', 'Jacket', 'Gloves', 'Footwear']
         }
         # Specify the subfolder name
-        subfolder:Optional[str] = gatherFolderPath("**/TrainingYolo")
+        subfolder:str = gatherFolderPath("**/TrainingYolo")
+        if subfolder == None: 
+            return "TrainingYolo directory was not found, aborting"
         # Create the subfolder if it doesn't exist
         os.makedirs(subfolder, exist_ok=True)
         
@@ -43,7 +46,7 @@ def createYaml() -> Optional[Exception]:
         with open(file_path, 'w') as file:
             yaml.dump(config, file, sort_keys=False)
     except:
-        return Exception("no Path was found, aborting")
+        return "an error occured during creation of YAML-Config file"
 
 if __name__ == "__main__":
     exit("not meant to be run")

--- a/modules/moduleYamlManagement.py
+++ b/modules/moduleYamlManagement.py
@@ -12,7 +12,7 @@ import yaml
 # -- / internal imports 
 from modules.moduleFileManagement import createPath, gatherFilePath, gatherFolderPath
 
-def createYaml():
+def createYaml() -> Optional[Exception]:
     '''
     searches for folders with name "test" and "valid" 
     if found: creates yaml file which contains those both folders as source for training datasets 
@@ -23,7 +23,7 @@ def createYaml():
         validPath = gatherFolderPath('valid')
         
         if testPath == None or validPath == None: 
-            raise Exception("Folder structure was not set up, aborting custom training")
+            return Exception("Folder structure was not set up, aborting custom training")
             
         config = {
             'train': createPath(testPath, 'images'),
@@ -32,8 +32,7 @@ def createYaml():
             'names': ['Helmet', 'Goggles', 'Jacket', 'Gloves', 'Footwear']
         }
         # Specify the subfolder name
-        subfolder:str = gatherFolderPath("**/TrainingYolo")
-        print(subfolder)
+        subfolder:Optional[str] = gatherFolderPath("**/TrainingYolo")
         # Create the subfolder if it doesn't exist
         os.makedirs(subfolder, exist_ok=True)
         
@@ -44,7 +43,7 @@ def createYaml():
         with open(file_path, 'w') as file:
             yaml.dump(config, file, sort_keys=False)
     except:
-        raise Exception("no Path was found, aborting")
+        return Exception("no Path was found, aborting")
 
 if __name__ == "__main__":
     exit("not meant to be run")

--- a/modules/moduleYoloV8.py
+++ b/modules/moduleYoloV8.py
@@ -137,8 +137,9 @@ def trainModel(model):
     # TODO remove Stringvalue
     configFile:Optional[str] = gatherFilePath("**/yolov8_config.yaml")
     if configFile == None:
-        createYaml()
-        return trainModel(model)
+        maybeException:Optional[Exception] = createYaml()
+        trainModel(model)
+        return 
 
     # Training.
     # TODO adapt output path to save results in "preTrainedYolo"
@@ -166,10 +167,11 @@ def offlineData(loadedModel):
 
     if st.button("Train Model"):
         try:
-            trainModel(loadedModel)
+            maybeException:Optional[Exception] = trainModel(loadedModel)
             # TODO improve verbosity to show more information ( what was trained, progress ..)
             st.write("Training complete!")
-        except RuntimeError:
+        except Exception as error:
+            st.error(error)
             st.error('No data set provided or the "data" folder is not unzipped')
 
 

--- a/modules/moduleYoloV8.py
+++ b/modules/moduleYoloV8.py
@@ -6,11 +6,11 @@ necesssary and is later piped or accessed by the UI.
 
 # --- /
 # -- / external imports 
+from ctypes import Union
 from typing import Optional
 import cv2 
 import time
 from matplotlib.cm import np
-import os
 from ultralytics import YOLO
 # TODO to be removed once refactored! 
 import streamlit as st
@@ -131,27 +131,36 @@ def runYoloOnImage(loadedModel:object,objectClasses:list,imgObj,requiredConfiden
 # -- / 
 # TODO add description 
 # TODO add function signature
-def trainModel(model):
-    # Load the model.
-    # model = YOLO('yolov8n.pt')
+def trainModel(model) -> Optional[str]:
+    # TODO remove boolean-Blindness --> String values ambigous! 
     # TODO remove Stringvalue
     configFile:Optional[str] = gatherFilePath("**/yolov8_config.yaml")
-    if configFile == None:
-        maybeException:Optional[Exception] = createYaml()
-        trainModel(model)
-        return 
-
-    # Training.
-    # TODO adapt output path to save results in "preTrainedYolo"
-    results = model.train(
-        data=gatherFilePath('**/yolov8_config.yaml'),
-        imgsz=1280,
-        epochs=1,
-        batch=8,
-        name='yolov8n_v8_50e'
-        )
-
-    return results
+    if configFile != None:
+        # TODO adapt output path to save results in "preTrainedYolo"
+        try: 
+            savedPath = gatherFolderPath("**/preTrainedYolo")
+            resultName:str = 'yolov8n_v8_50e'
+            savingLocation = createPath(savedPath,result_name)
+            results = model.train(
+                data=gatherFilePath('**/yolov8_config.yaml'),
+                imgsz=1280,
+                epochs=1,
+                batch=8,
+                name= resultName,
+                save_dir= savingLocation
+                )
+            
+        except : 
+            return "error running model"
+        
+    else: 
+        # not path was found: 
+        possibleError:Optional[str] = createYaml()
+        if possibleError != None: 
+            return possibleError
+        # if created with no error, run again 
+        return "Yaml was created, re run test once more"
+    # return results
 
 
 # --- /
@@ -166,13 +175,12 @@ def offlineData(loadedModel):
     st.write("Click the 'Train Model' button to start training.")
 
     if st.button("Train Model"):
-        try:
-            maybeException:Optional[Exception] = trainModel(loadedModel)
-            # TODO improve verbosity to show more information ( what was trained, progress ..)
-            st.write("Training complete!")
-        except Exception as error:
-            st.error(error)
-            st.error('No data set provided or the "data" folder is not unzipped')
+        possibleError:Optional[str] = trainModel(loadedModel)
+        if possibleError != None: 
+            st.error(possibleError)
+            return # aborting function
+        # TODO improve verbosity to show more information ( what was trained, progress ..)
+        st.write("Training complete!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this PR tries to resolve #43 but instead of handling the possible errors we are using string messages and check whether a string was supplied or not. 
This was done because with a string being named and returned we can display the actual error easier instead of checking for each possible exception that could occur. 

It is not an ideal solution however I think that It covers the expected behavior of showcasing errors upon running the training process the best. 