### PR TITLE
added feature to evaluate and save  - also display - object detection results on images

### DIFF
--- a/UI/uiFoundation.py
+++ b/UI/uiFoundation.py
@@ -6,6 +6,7 @@ File contains basic structure of Ui, which is supplied by Streamlit
 # --- / 
 # -- / external imports 
 from streamlit_option_menu import option_menu
+from UI.uiShowEvaluation import displayResultSelection
 
 # --- / 
 # -- / internal imports 
@@ -24,7 +25,7 @@ def SelectProgramMode()  :
     function displaying a streamlit menu with several options
     upon selection of a module to execute, said module is executed 
     '''
-    appModeSelection = ["Readme File", "Run SSD", "Yolov8", "Show the Code"];
+    appModeSelection = ["Readme File", "Run SSD", "Yolov8", "Show the Code","Display Evaluations"];
     appModeSelectionIcons = ["book", "display", "display", "cloud-download"]
     app_mode = option_menu(
         None, 
@@ -45,6 +46,8 @@ def SelectProgramMode()  :
     elif app_mode == appModeSelection[3]:
         # showing source code for 
         ShowSourceCode()
+    elif app_mode == appModeSelection[4]:
+        displayResultSelection()
 
 # --- / 
 # -- / 

--- a/UI/uiShowEvaluation.py
+++ b/UI/uiShowEvaluation.py
@@ -1,0 +1,83 @@
+'''
+file containing UI elements to display resutls of various detections
+
+'''
+# --- /
+# -- / external imports 
+from typing import Optional
+import numpy
+import streamlit as st  
+
+# --- / 
+# -- / internal imports
+from modules.moduleFileManagement import convertArrayToImage, convertListToArray, gatherFolderContent, gatherFolderPath, loadFromFile
+
+
+def displayResultSelection(): 
+    ''' 
+    function generating UI for showing and examining stored test images
+    
+    '''
+    foundResults:Optional[list] = gatherFolderContent("**/detectionResults")
+    if (foundResults == None) or (foundResults == []):
+        st.error("It seems no evaluation data was retrieved and saved yet.")
+        st.error("please run some object detections and save their results after evaluating them!")
+        # st.error("No results were found, sorry")
+        return
+    
+    st.divider()
+    st.markdown("## examine previous detections and their evaluation")
+    st.markdown("Below you can view all saved object detections of images run on different models.")
+    st.markdown("this examination will give you some insight on several aspects:")
+    st.markdown("- how many objects were detected by the model")
+    st.markdown("- at which confidence")
+    st.markdown("- how many objects are actually contained in the image") 
+    st.markdown("- how many objects were examined wrong by the model")
+    
+    if len(foundResults) != 1:
+        selectedEvaluation:int = st.slider("Select Source to show", 
+                                   min_value=1, 
+                                   max_value=len(foundResults),
+                                   step=1,
+                                  value=0
+                                   )
+        if selectedEvaluation == None:
+            return   
+        selectedEvaluation -= 1 
+    else: 
+        selectedEvaluation=0
+    
+    st.divider()
+    
+    selectedPath:str = foundResults[selectedEvaluation]
+    try:
+        extractedDictionary: Optional[dict] = loadFromFile(selectedPath)
+        if extractedDictionary == None:
+            raise Exception()
+        
+        
+        col1,col2 = st.columns(2)
+        
+        with col1:
+            #displaying image
+            extractedArray:numpy.ndarray = convertListToArray(extractedDictionary["imageArray"])
+            extractedDimensions:list = extractedDictionary["imageDimension"]
+            convertedImageArray:numpy.ndarray = convertArrayToImage(extractedArray,extractedDimensions)
+            st.image(convertedImageArray,"extracted image",use_column_width=True)
+            
+        with col2: 
+            st.markdown("## Evaluation of Object detection:")
+            st.markdown("run **model** : {}".format(extractedDictionary["usedModel"]))
+            st.markdown("applied **confidence** : {}".format(extractedDictionary["confidence"]) )
+            st.markdown("detected objects **by model** : {}".format(extractedDictionary["amountDetected"]))
+            st.markdown("actual amount of objects: {}".format(extractedDictionary["actualAmount"]))
+            st.markdown("mistakenly detected Objects: {}".format(extractedDictionary["faultyDetection"]))
+            
+            
+        
+        
+    except:
+        st.error("could not extract information")
+        return
+        
+    

--- a/UI/uiYolo.py
+++ b/UI/uiYolo.py
@@ -17,7 +17,7 @@ import tempfile
 
 # --- / 
 # -- / internal imports 
-from modules.moduleFileManagement import convertArrayToImage, convertImageTo1DArray, gatherFilePath, gatherFolderContent, loadFromFile, prepareImageToSave, saveToFile, convertListToArray
+from modules.moduleFileManagement import convertArrayToImage, convertImageTo1DArray, gatherFilePath, gatherFolderContent, loadFromFile, prepareImageToSave, saveEvaluationToFile, saveToFile, convertListToArray
 from modules.moduleYoloV8 import initializeModel, runYoloOnImage, offlineData
 from UI.uiRunVideo import interfaceVideo
 
@@ -239,26 +239,17 @@ def processImage(loadedModel:object,objectClasses:list,selectedImage,confidence:
                 "imageArray": imageListRepresentation,
                 "imageDimension": imageDimension
                 }
-            saveToFile(dictDetectionEval)
+            saveEvaluationToFile(dictDetectionEval,dictDetectionEval["usedModel"])
             
             # --- / 
             # -- / testing only!!
-            pathToTest = gatherFilePath("**/testEvaluation.json")
-            maybeDict:Optional[dict] = loadFromFile(pathToTest)
+            # pathToTest = gatherFilePath("**/testEvaluation.json")
+            # maybeDict:Optional[dict] = loadFromFile(pathToTest)
             
-            extractedArray = convertListToArray(maybeDict["imageArray"])
-            arrayDimension = maybeDict["imageDimension"]
-            imageArray = convertArrayToImage(extractedArray,arrayDimension)
-            st.image(imageArray,"extracted image!!")
-            
-            try:
-                with st.expander("Detection Results"):
-                    for box in detectionResult['foundObjects']:
-                        st.write(box)
-            
-            except Exception as ex:
-                st.write("No image was uploaded yet!")
-
+            # extractedArray = convertListToArray(maybeDict["imageArray"])
+            # arrayDimension = maybeDict["imageDimension"]
+            # imageArray = convertArrayToImage(extractedArray,arrayDimension)
+            # st.image(imageArray,"extracted image!!")
 # --- / 
 # -- / 
 # TODO refactor to another file --> does not belong here! 

--- a/UI/uiYolo.py
+++ b/UI/uiYolo.py
@@ -6,15 +6,18 @@ It will be removed once we have refactored and **united** our webinterface so th
 
 # --- / 
 # -- / external imports 
+from base64 import decode
 from typing import Optional
 from PIL import Image
-from numpy import select # ought to be removed at a later point 
+from altair.utils.core import np
+# TODO remove from this file  --> no logic!
+import numpy
 import streamlit as st
 import tempfile
 
 # --- / 
 # -- / internal imports 
-from modules.moduleFileManagement import gatherFilePath, gatherFolderContent
+from modules.moduleFileManagement import convertArrayToImage, convertImageTo1DArray, gatherFilePath, gatherFolderContent, loadFromFile, prepareImageToSave, saveToFile, convertListToArray
 from modules.moduleYoloV8 import initializeModel, runYoloOnImage, offlineData
 from UI.uiRunVideo import interfaceVideo
 
@@ -116,7 +119,7 @@ def runYoloInterface():
     # TODO refactor to separate function!
     if sourceTypeSelected == SourceTypes[0]:
         selectedImage = selectFileSource(True,sourceOptions,sourceOptionSelected)
-        processImage(model,classes,selectedImage,confidence)
+        processImage(model,classes,selectedImage,confidence,modelSelected)
     
     elif sourceTypeSelected == SourceTypes[1]:
         selectedVideo = selectFileSource(False,sourceOptions,sourceOptionSelected)
@@ -202,7 +205,7 @@ def selectFileSource(isImage:bool,SourceOptions:list,selectedSource:Optional[str
     
     
     
-def processImage(loadedModel:object,objectClasses:list,selectedImage,confidence:float):
+def processImage(loadedModel:object,objectClasses:list,selectedImage,confidence:float,usedModel:str):
      
     # once image file was loaded or not 
         col1, col2 = st.columns(2)
@@ -213,6 +216,41 @@ def processImage(loadedModel:object,objectClasses:list,selectedImage,confidence:
             detectionResult = runYoloOnImage(loadedModel,objectClasses,selectedImage,confidence)
             st.image(detectionResult['image'], caption="Detected Image",
                      use_column_width=True)
+            
+            # --- 
+            # - logic for evaluating results
+            dictOfEvaluation:Optional[dict] = formEvaluateResult()
+            if dictOfEvaluation == None: 
+                return 
+            
+            # collecting all results: 
+            
+            # convertedImage:numpy.ndarray = convertImageTo1DArray(detectionResult["image"])
+            # imageStringRepresentation:str = convertedImage.tolist()
+            imageListRepresentation:list = prepareImageToSave(detectionResult["image"])
+            imageDimension:tuple = detectionResult["image"].shape
+            
+            dictDetectionEval:dict= {
+                "usedModel": usedModel,
+                "confidence": confidence,
+                "amountDetected": len(detectionResult["foundObjects"]),
+                "actualAmount": dictOfEvaluation["amount"],
+                "faultyDetection": dictOfEvaluation["faulty"],
+                "imageArray": imageListRepresentation,
+                "imageDimension": imageDimension
+                }
+            saveToFile(dictDetectionEval)
+            
+            # --- / 
+            # -- / testing only!!
+            pathToTest = gatherFilePath("**/testEvaluation.json")
+            maybeDict:Optional[dict] = loadFromFile(pathToTest)
+            
+            extractedArray = convertListToArray(maybeDict["imageArray"])
+            arrayDimension = maybeDict["imageDimension"]
+            imageArray = convertArrayToImage(extractedArray,arrayDimension)
+            st.image(imageArray,"extracted image!!")
+            
             try:
                 with st.expander("Detection Results"):
                     for box in detectionResult['foundObjects']:
@@ -220,7 +258,6 @@ def processImage(loadedModel:object,objectClasses:list,selectedImage,confidence:
             
             except Exception as ex:
                 st.write("No image was uploaded yet!")
-
 
 # --- / 
 # -- / 
@@ -276,3 +313,29 @@ def processWebcam(loadedModel:object,objectClasses:list,requiredConfidence:float
     '''
     interfaceVideo(loadedModel,None,objectClasses,requiredConfidence)
     
+
+# dictionary returned should contain: 
+# - usedModel -> to be displayed upon showcase
+# - confidence level : 
+# - detected amount of objects
+# - actual amount of objects detected -> user input!
+# - amount of faulty detection -> user input!
+# - image encoded as 1D-array 
+# - image dimensions used to reshape accordingly
+
+# --- / 
+# -- / 
+def formEvaluateResult()-> Optional[dict]: 
+    with st.form("evaluating results"):
+        st.write("insert the correct data for this detected image")
+        st.write("once done, click the submit-button to save the result")
+        actualDetection:int = int(st.number_input("actual amount of detections",min_value=0,max_value=20,step=1))
+        amountFaultyDetection:int = int(st.number_input("amount of faulty detections",min_value=0,max_value=20,step=1))
+        submitted = st.form_submit_button("save results")
+        if submitted:
+            resultDict:dict = {
+                "amount": actualDetection,
+                "faulty": amountFaultyDetection
+            }
+            return resultDict
+        return None

--- a/modules/moduleFileManagement.py
+++ b/modules/moduleFileManagement.py
@@ -7,9 +7,11 @@ This file contains several functions to manage, access, read or modify files
 import glob 
 import platform
 import os
+import json
 from typing import Optional
+import time
 
-from numpy import log
+import numpy
 
 # --- /
 # -- / function to read a given file
@@ -113,6 +115,98 @@ def createPath(rootPath:str, folder:str) -> str:
     convertedQueryPath:str = rootPath + os.sep + folder
     return convertedQueryPath
 
+# --- /
+# -- / 
+def convert2Json(queriedDict:dict) ->Optional[str]:
+    try:
+        convertedDict:str =json.dumps(queriedDict)
+        return convertedDict
+    except:
+        return None
+# --- /
+# -- /
+def convert2Dict(queriedString:str)-> Optional[dict]:
+    try:
+        convertedString:dict =json.loads(queriedString)
+        return convertedString
+    except:
+        return None
 
+# --- /
+# -- / 
+
+def saveToFile(dictToSave:dict):
+    convertedDict:Optional[str] = convert2Json(dictToSave)
+    
+    if convertedDict ==None:
+        raise Exception("could not convert to json string")
+    try:
+        resultFolder:str = gatherFolderPath("**/detectionResults")
+        fileName:str = "{}_{}.json".format(dictToSave["usedModel"],time.time())
+        finalFilePath:str = createPath(resultFolder,fileName)
+        with open(finalFilePath,"x") as file :
+            file.write(convertedDict)
+    except:
+        raise Exception("tscha")
+    
+# --- /
+# -- /   
+def loadFromFile(pathFile:str)-> Optional[dict]:
+    try:
+        with open(pathFile,"r") as file :
+            content:str = file.read()
+        maybeDictionary:Optional[dict] = convert2Dict(content)
+        return maybeDictionary
+    except:
+        return None
+    
+# --- / 
+# -- / 
+def convertImageTo1DArray(ImageArray:numpy.ndarray)-> numpy.ndarray:
+    '''
+    function converting 3D-image array to 1D representation 
+    
+    returns 1D-array of input imagearray
+    ''' 
+    compressedArray = ImageArray.reshape(-2)
+    return compressedArray
+# --- / 
+# -- / 
+
+def convertArrayToImage(compressedArray:numpy.ndarray,arrayDimension:tuple) -> numpy.ndarray:
+    ''' 
+    function converting a 1-Dimensional numpy-array to 3D-array 
+    aligning with shape of image-like representation used by streamlit and more
+    
+    returns numpy.ndarray in shape of given **arrayDimension**
+    
+    ## example usage: 
+    
+    '''
+    reshapedArray:numpy.ndarray = compressedArray.reshape(arrayDimension)
+    return reshapedArray
+# --- / 
+# -- / 
+ 
+def convertListToArray(arraylist:list) -> numpy.ndarray:
+    return numpy.asarray(arraylist)
+# --- / 
+# -- / 
+
+def prepareImageToSave(imageArray:numpy.ndarray) -> Optional[list]:
+    '''
+    function taking an imageArray(shape of(n,d,3)) and converting it to saveable List 
+    returns said *1D-list* 
+    
+    ## example usage: 
+    prepareImageToSave([[0,1,1],[1,1,0][1,1,1]]) -> [0,1,1,1,1,0,1,1,1]  
+    '''
+    try:
+        oneDimArray:numpy.ndarray = convertImageTo1DArray(imageArray)
+        listOfArray:list = oneDimArray.tolist()
+        return listOfArray
+    except:
+        return None
+        
 if __name__ == "__main__":
     exit("not meant to be run")

--- a/modules/moduleFileManagement.py
+++ b/modules/moduleFileManagement.py
@@ -135,23 +135,56 @@ def convert2Dict(queriedString:str)-> Optional[dict]:
 # --- /
 # -- / 
 
-def saveToFile(dictToSave:dict):
+def saveEvaluationToFile(dictToSave:dict,filePrefix:str) -> Optional[str]:
+    ''' 
+    wrapping function for **saveToFile** specifically for saving detectionEvaluation
+    
+    ## example usage: 
+    saveEvaluationToFile(dictionary,"savedDict") -> saving file to detectionResults/savedDict[...].json 
+    '''
+    
+    folderPath:str = "detectionResults"
+    return saveToFile(dictToSave,filePrefix,folderPath)
+    
+
+def saveToFile(dictToSave:dict,filePrefix:str,folderPath:str) -> Optional[str]:
+    ''' 
+    function taking a dictionary and a prefix for the file. 
+    Saving the dictionary as json encoded String.
+    
+     
+    this function was specifically written for saving dictionary-blobs from objectdetection evaluations
+    returns a **String** representing the path to the file
+    ## example usage:
+    saveToFile(dictionary,"savedDict") -> will save the given file and return filePath
+    '''
+    
     convertedDict:Optional[str] = convert2Json(dictToSave)
     
     if convertedDict ==None:
         raise Exception("could not convert to json string")
     try:
-        resultFolder:str = gatherFolderPath("**/detectionResults")
-        fileName:str = "{}_{}.json".format(dictToSave["usedModel"],time.time())
+        resultFolder:str = gatherFolderPath("**/{}".format(folderPath))
+        fileName:str = "{}_{}.json".format(filePrefix,time.time())
         finalFilePath:str = createPath(resultFolder,fileName)
         with open(finalFilePath,"x") as file :
             file.write(convertedDict)
+        return finalFilePath
     except:
-        raise Exception("tscha")
+        return None
     
 # --- /
 # -- /   
 def loadFromFile(pathFile:str)-> Optional[dict]:
+    '''
+    function taking path to json file, parsing and returning the contained json object as dictionary 
+    returns **Dictionary** if the given path contains one
+    
+    ## example usage: 
+    gatheredPath = gatherFilePath("detectionResults/testEvaluation.json")
+    loadFromFile(gatheredPath) -> returns given dictionary in file
+    '''
+    
     try:
         with open(pathFile,"r") as file :
             content:str = file.read()
@@ -189,6 +222,10 @@ def convertArrayToImage(compressedArray:numpy.ndarray,arrayDimension:tuple) -> n
 # -- / 
  
 def convertListToArray(arraylist:list) -> numpy.ndarray:
+    ''' 
+    function takes a list and returns as **numpy.ndarray**
+    '''
+    
     return numpy.asarray(arraylist)
 # --- / 
 # -- / 

--- a/modules/moduleYoloV8.py
+++ b/modules/moduleYoloV8.py
@@ -173,5 +173,6 @@ def offlineData(loadedModel):
             st.error('No data set provided or the "data" folder is not unzipped')
 
 
+
 if __name__ == "__main__":
     exit("not meant to be run")


### PR DESCRIPTION
This PR introduces the possibility to evaluate any detection being run on our yolo model. 
It is only available for **images** as it seems rather useless for videos. 
Each Evaluation is further saved into a given directory **detectionResults** and can be read and displayed with the use of the **Display Evaluations** Option in our top-menu. 

![image](https://github.com/nicolasseng/teamproject-objectdetection/assets/63316422/ddaa11fa-1c27-48a2-8a4e-cfe761f22a52)
